### PR TITLE
Add code snippets and demo for bulk image upload

### DIFF
--- a/content/blogs/quick-bulk-image-upload/README.md
+++ b/content/blogs/quick-bulk-image-upload/README.md
@@ -1,1 +1,80 @@
-# placeholder to create a folder
+# Filestack Bulk Image Upload Demo
+
+## Filestack Bulk Image Upload Example
+
+This project demonstrates a web-based image bulk upload functionality using the Filestack API. It allows users to upload multiple images simultaneously, display resized versions of uploaded images in a grid layout, and provides links to view the original images.
+
+---
+
+### Features
+- **Bulk Upload:** Upload up to 50 images simultaneously, with the option to increase the maximum limit as needed.
+- **Responsive Grid Display:** Uploaded images are displayed in a neat, responsive grid.
+- **Filestack Transformations:** Images are resized and cropped to a uniform 200x200 pixels using Filestack's transformation features.
+- **Dynamic File Info:** Each uploaded image includes its name and a link to view the full-size image.
+
+---
+
+### Live Demo
+
+To see this example in action, follow these steps:
+1. Clone or download the project files.
+2. Open the `index.html` file in any modern web browser.
+3. Replace `YOUR_API_KEY` in the JavaScript code with your Filestack API key.
+
+---
+
+### Usage
+
+1. Click the **"Upload Images"** button to open the Filestack file picker.
+2. Select up to 50 images from your device (maximum limit is set to 50 in this example).
+3. Once uploaded, the images will be displayed in a responsive grid.
+
+---
+
+### File Details
+
+#### HTML Structure
+- `index.html`: Contains the main HTML structure and JavaScript logic for the demo.
+
+#### CSS
+- Inline CSS styles for responsive grid design and aesthetic user interface.
+
+#### JavaScript
+- Uses Filestack's JavaScript SDK for file uploads and image transformations.
+
+---
+
+### How to Run
+
+1. **Clone the Repository:**
+
+   `git clone <repository-url>`
+   
+   `cd <repository-folder>`
+
+3. **Edit API Key:**
+
+- Open index.html and replace YOUR_API_KEY with your Filestack API key.
+
+3. **Open in Browser:**
+
+- Double-click the `index.html` file or serve it via a local web server. (Using a local server is recommended, as some features may not function correctly when opened directly in the file explorer.)
+
+### Dependencies
+
+- **Filestack SDK:** Included via CDN:
+  `<script src="https://static.filestackapi.com/filestack-js/3.27.0/filestack.min.js"></script>`
+
+### Filestack Transformations Used
+
+- **Resize:**
+  - Ensures images are uniformly cropped to 200x200 pixels.
+  - Example transformation URL:
+    `https://cdn.filestackcontent.com/resize=width:200,height:200,fit:crop/<file_handle>`
+
+### Notes
+
+- Ensure you have a valid Filestack API key.
+- Use modern browsers (e.g., Chrome, Edge, Firefox) for the best experience.
+
+[Visit Filestack](https://www.filestack.com)

--- a/content/blogs/quick-bulk-image-upload/README.md
+++ b/content/blogs/quick-bulk-image-upload/README.md
@@ -1,0 +1,1 @@
+# placeholder to create a folder

--- a/content/blogs/quick-bulk-image-upload/code-snippets/file-picker-upload
+++ b/content/blogs/quick-bulk-image-upload/code-snippets/file-picker-upload
@@ -1,0 +1,5 @@
+// Open the picker and bulk file upload
+      client.picker({
+        maxFiles: 50, // Set the max number of files to upload
+        accept: ['image/*'], // Accept only image files
+        uploadInBackground: false, // Ensures uploads complete before closing picker

--- a/content/blogs/quick-bulk-image-upload/code-snippets/image-transformation.js
+++ b/content/blogs/quick-bulk-image-upload/code-snippets/image-transformation.js
@@ -1,0 +1,14 @@
+// Resize and crop each uploaded image, then display it in a grid with the file name and a clickable link to view the original image.
+
+uploadedFiles.forEach(file => {
+
+                //Filestack transformation
+                const resizedUrl = `https://cdn.filestackcontent.com/resize=width:200,height:200,fit:crop/${file.handle}`;
+                uploadStatus += `
+                <div>
+                    <img src="${resizedUrl}" alt="${file.filename}" />
+                    <p>${file.filename}</p>
+                    <a href="${file.url}" target="_blank">View Image</a>
+                </div>
+                `;
+            });

--- a/content/blogs/quick-bulk-image-upload/code-snippets/style.css
+++ b/content/blogs/quick-bulk-image-upload/code-snippets/style.css
@@ -1,0 +1,84 @@
+/* General Page Styles */
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+    }
+
+    h1 {
+      color: #333;
+      margin-bottom: 20px;
+      text-align: center;
+    }
+
+    button {
+      background-color: #007bff;
+      color: white;
+      padding: 10px 20px;
+      border: none;
+      border-radius: 5px;
+      font-size: 16px;
+      cursor: pointer;
+      transition: background-color 0.3s;
+    }
+
+    button:hover {
+      background-color: #0056b3;
+    }
+
+    #upload-status {
+      margin-top: 30px;
+      width: 80%;
+      max-width: 1200px;
+    }
+
+    #upload-status h2 {
+      text-align: center;
+      color: #333;
+      margin-bottom: 20px;
+    }
+
+    .image-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 20px;
+    }
+
+    .image-grid img {
+      width: 100%;
+      border-radius: 10px;
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+      transition: transform 0.3s, box-shadow 0.3s;
+    }
+
+    .image-grid img:hover {
+      transform: scale(1.05);
+      box-shadow: 0 8px 12px rgba(0, 0, 0, 0.2);
+    }
+
+    .image-grid p {
+    text-align: center;
+    font-size: 14px;
+    color: #333; 
+    margin-top: 10px; 
+    margin-bottom: 5px; 
+    }
+
+    .image-grid a {
+      text-decoration: none;
+      color: #007bff;
+      font-size: 14px;
+      display: block;
+      margin-top: 5px;
+      text-align: center;
+    }
+
+    .image-grid a:hover {
+      color: #0056b3;
+    }

--- a/content/blogs/quick-bulk-image-upload/demo/index.html
+++ b/content/blogs/quick-bulk-image-upload/demo/index.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Filestack Bulk Upload</title>
+  <script src="https://static.filestackapi.com/filestack-js/3.27.0/filestack.min.js"></script>
+  <style>
+    /* General Page Styles */
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+    }
+
+    h1 {
+      color: #333;
+      margin-bottom: 20px;
+      text-align: center;
+    }
+
+    button {
+      background-color: #007bff;
+      color: white;
+      padding: 10px 20px;
+      border: none;
+      border-radius: 5px;
+      font-size: 16px;
+      cursor: pointer;
+      transition: background-color 0.3s;
+    }
+
+    button:hover {
+      background-color: #0056b3;
+    }
+
+    #upload-status {
+      margin-top: 30px;
+      width: 80%;
+      max-width: 1200px;
+    }
+
+    #upload-status h2 {
+      text-align: center;
+      color: #333;
+      margin-bottom: 20px;
+    }
+
+    .image-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 20px;
+    }
+
+    .image-grid img {
+      width: 100%;
+      border-radius: 10px;
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+      transition: transform 0.3s, box-shadow 0.3s;
+    }
+
+    .image-grid img:hover {
+      transform: scale(1.05);
+      box-shadow: 0 8px 12px rgba(0, 0, 0, 0.2);
+    }
+
+    .image-grid p {
+    text-align: center;
+    font-size: 14px;
+    color: #333; 
+    margin-top: 10px; 
+    margin-bottom: 5px; 
+    }
+
+    .image-grid a {
+      text-decoration: none;
+      color: #007bff;
+      font-size: 14px;
+      display: block;
+      margin-top: 5px;
+      text-align: center;
+    }
+
+    .image-grid a:hover {
+      color: #0056b3;
+    }
+  </style>
+</head>
+<body>
+  <h1>Filestack Bulk Upload Example</h1>
+  <button id="upload-btn">Upload Images</button>
+  <div id="upload-status"></div>
+
+  <script>
+    // Initialize Filestack client with your API Key
+    const client = filestack.init('YOUR_API_KEY'); // Replace with your Filestack API key 
+
+    // Add event listener to the button
+    document.getElementById('upload-btn').addEventListener('click', () => {
+      // Open the picker
+      client.picker({
+        maxFiles: 50, // Set the max number of files to upload
+        accept: ['image/*'], // Accept only image files
+        uploadInBackground: false, // Ensures uploads complete before closing picker
+        onUploadDone: (result) => {
+            // Display uploaded files with resize and other transformations
+            const uploadedFiles = result.filesUploaded;
+            let uploadStatus = '<h2>Uploaded Images:</h2>';
+            uploadStatus += '<div class="image-grid">';
+            uploadedFiles.forEach(file => {
+                const resizedUrl = `https://cdn.filestackcontent.com/resize=width:200,height:200,fit:crop/${file.handle}`;
+                uploadStatus += `
+                <div>
+                    <img src="${resizedUrl}" alt="${file.filename}" />
+                    <p>${file.filename}</p>
+                    <a href="${file.url}" target="_blank">View Image</a>
+                </div>
+                `;
+            });
+          uploadStatus += '</div>';
+          document.getElementById('upload-status').innerHTML = uploadStatus;
+        },
+      }).open();
+    });
+  </script>
+</body>
+</html>

--- a/content/blogs/quick-bulk-image-upload/demo/readme.md
+++ b/content/blogs/quick-bulk-image-upload/demo/readme.md
@@ -26,7 +26,7 @@ To see this example in action, follow these steps:
 ### Usage
 
 1. Click the **"Upload Images"** button to open the Filestack file picker.
-2. Select up to 50 images from your device.
+2. Select up to 50 images from your device (maximum limit is set to 50 in this example).
 3. Once uploaded, the images will be displayed in a responsive grid.
 
 ---
@@ -58,7 +58,7 @@ To see this example in action, follow these steps:
 
 3. **Open in Browser:**
 
-- Double-click the index.html file or serve it via a local web server.
+- Double-click the `index.html` file or serve it via a local web server. (Using a local server is recommended, as some features may not function correctly when opened directly in the file explorer.)
 
 ### Dependencies
 
@@ -77,4 +77,4 @@ To see this example in action, follow these steps:
 - Ensure you have a valid Filestack API key.
 - Use modern browsers (e.g., Chrome, Edge, Firefox) for the best experience.
 
-
+[Visit Filestack](https://www.filestack.com)

--- a/content/blogs/quick-bulk-image-upload/demo/readme.md
+++ b/content/blogs/quick-bulk-image-upload/demo/readme.md
@@ -78,5 +78,7 @@ To see this example in action, follow these steps:
 - Use modern browsers (e.g., Chrome, Edge, Firefox) for the best experience.
 
 [Visit Filestack](https://www.filestack.com)
-<a href="https://www.filestack.com" target="_blank">Visit Filestack</a>
+
+<a href="https://www.filestack.com/" target="_blank" rel="noopener noreferrer">Visit Filestack</a>
+
 

--- a/content/blogs/quick-bulk-image-upload/demo/readme.md
+++ b/content/blogs/quick-bulk-image-upload/demo/readme.md
@@ -78,7 +78,3 @@ To see this example in action, follow these steps:
 - Use modern browsers (e.g., Chrome, Edge, Firefox) for the best experience.
 
 [Visit Filestack](https://www.filestack.com)
-
-<a href="https://www.filestack.com/" target="_blank" rel="noopener noreferrer">Visit Filestack</a>
-
-

--- a/content/blogs/quick-bulk-image-upload/demo/readme.md
+++ b/content/blogs/quick-bulk-image-upload/demo/readme.md
@@ -1,0 +1,79 @@
+# Filestack Bulk Upload Demo
+
+## Filestack Bulk Upload Example
+
+This project demonstrates a web-based image bulk upload functionality using the Filestack API. It allows users to upload multiple images simultaneously, display resized versions of uploaded images in a grid layout, and provides links to view the original images.
+
+---
+
+### Features
+- **Bulk Upload:** Upload up to 50 images simultaneously.
+- **Responsive Grid Display:** Uploaded images are displayed in a neat, responsive grid.
+- **Filestack Transformations:** Images are resized and cropped to a uniform 200x200 pixels using Filestack's transformation features.
+- **Dynamic File Info:** Each uploaded image includes its name and a link to view the full-size image.
+
+---
+
+### Live Demo
+
+To see this example in action, follow these steps:
+1. Clone or download the project files.
+2. Open the `index.html` file in any modern web browser.
+3. Replace `YOUR_API_KEY` in the JavaScript code with your Filestack API key.
+
+---
+
+### Usage
+
+1. Click the **"Upload Images"** button to open the Filestack file picker.
+2. Select up to 50 images from your device.
+3. Once uploaded, the images will be displayed in a responsive grid.
+
+---
+
+### File Details
+
+#### HTML Structure
+- `index.html`: Contains the main HTML structure and JavaScript logic for the demo.
+
+#### CSS
+- Inline CSS styles for responsive grid design and aesthetic user interface.
+
+#### JavaScript
+- Uses Filestack's JavaScript SDK for file uploads and image transformations.
+
+---
+
+### How to Run
+
+1. **Clone the Repository:**
+
+   `git clone <repository-url>`
+   `cd <repository-folder>`
+
+2. **Edit API Key:**
+
+- Open index.html and replace YOUR_API_KEY with your Filestack API key.
+
+3. **Open in Browser:**
+
+- Double-click the index.html file or serve it via a local web server.
+
+### Dependencies
+
+- **Filestack SDK:** Included via CDN:
+  `<script src="https://static.filestackapi.com/filestack-js/3.27.0/filestack.min.js"></script>`
+
+### Filestack Transformations Used
+
+- **Resize:**
+  - Ensures images are uniformly cropped to 200x200 pixels.
+  - Example transformation URL:
+    `https://cdn.filestackcontent.com/resize=width:200,height:200,fit:crop/<file_handle>`
+
+### Notes
+
+- Ensure you have a valid Filestack API key.
+- Use modern browsers (e.g., Chrome, Edge, Firefox) for the best experience.
+
+

--- a/content/blogs/quick-bulk-image-upload/demo/readme.md
+++ b/content/blogs/quick-bulk-image-upload/demo/readme.md
@@ -1,6 +1,6 @@
-# Filestack Bulk Upload Demo
+# Filestack Bulk Image Upload Demo
 
-## Filestack Bulk Upload Example
+## Filestack Bulk Image Upload Example
 
 This project demonstrates a web-based image bulk upload functionality using the Filestack API. It allows users to upload multiple images simultaneously, display resized versions of uploaded images in a grid layout, and provides links to view the original images.
 

--- a/content/blogs/quick-bulk-image-upload/demo/readme.md
+++ b/content/blogs/quick-bulk-image-upload/demo/readme.md
@@ -78,3 +78,5 @@ To see this example in action, follow these steps:
 - Use modern browsers (e.g., Chrome, Edge, Firefox) for the best experience.
 
 [Visit Filestack](https://www.filestack.com)
+<a href="https://www.filestack.com" target="_blank">Visit Filestack</a>
+

--- a/content/blogs/quick-bulk-image-upload/demo/readme.md
+++ b/content/blogs/quick-bulk-image-upload/demo/readme.md
@@ -7,7 +7,7 @@ This project demonstrates a web-based image bulk upload functionality using the 
 ---
 
 ### Features
-- **Bulk Upload:** Upload up to 50 images simultaneously.
+- **Bulk Upload:** Upload up to 50 images simultaneously, with the option to increase the maximum limit as needed.
 - **Responsive Grid Display:** Uploaded images are displayed in a neat, responsive grid.
 - **Filestack Transformations:** Images are resized and cropped to a uniform 200x200 pixels using Filestack's transformation features.
 - **Dynamic File Info:** Each uploaded image includes its name and a link to view the full-size image.

--- a/content/blogs/quick-bulk-image-upload/demo/readme.md
+++ b/content/blogs/quick-bulk-image-upload/demo/readme.md
@@ -49,9 +49,10 @@ To see this example in action, follow these steps:
 1. **Clone the Repository:**
 
    `git clone <repository-url>`
+   
    `cd <repository-folder>`
 
-2. **Edit API Key:**
+3. **Edit API Key:**
 
 - Open index.html and replace YOUR_API_KEY with your Filestack API key.
 


### PR DESCRIPTION
This pull request adds the following:
- A new folder for the "Bulk Image Upload" blog code snippets.
- Demo files demonstrating the use of the Filestack API for bulk image uploads.
- A README.md file explaining the usage and setup of the demo.
